### PR TITLE
af_tempo.c: fix checking of samples and zero frame counts

### DIFF
--- a/libavfilter/af_atempo.c
+++ b/libavfilter/af_atempo.c
@@ -18,25 +18,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-/**
- * @file
- * tempo scaling audio filter -- an implementation of WSOLA algorithm
- *
- * Based on MIT licensed yaeAudioTempoFilter.h and yaeAudioFragment.h
- * from Apprentice Video player by Pavel Koshevoy.
- * https://sourceforge.net/projects/apprenticevideo/
- *
- * An explanation of SOLA algorithm is available at
- * http://www.surina.net/article/time-and-pitch-scaling.html
- *
- * WSOLA is very similar to SOLA, only one major difference exists between
- * these algorithms.  SOLA shifts audio fragments along the output stream,
- * where as WSOLA shifts audio fragments along the input stream.
- *
- * The advantage of WSOLA algorithm is that the overlap region size is
- * always the same, therefore the blending function is constant and
- * can be precomputed.
- */
+ /**
+  * @file
+  * tempo scaling audio filter -- an implementation of WSOLA algorithm
+  *
+  * Based on MIT licensed yaeAudioTempoFilter.h and yaeAudioFragment.h
+  * from Apprentice Video player by Pavel Koshevoy.
+  * https://sourceforge.net/projects/apprenticevideo/
+  *
+  * An explanation of SOLA algorithm is available at
+  * http://www.surina.net/article/time-and-pitch-scaling.html
+  *
+  * WSOLA is very similar to SOLA, only one major difference exists between
+  * these algorithms.  SOLA shifts audio fragments along the output stream,
+  * where as WSOLA shifts audio fragments along the input stream.
+  *
+  * The advantage of WSOLA algorithm is that the overlap region size is
+  * always the same, therefore the blending function is constant and
+  * can be precomputed.
+  */
 
 #include <float.h>
 #include "libavutil/avassert.h"
@@ -50,9 +50,9 @@
 #include "audio.h"
 #include "internal.h"
 
-/**
- * A fragment of audio waveform
- */
+  /**
+   * A fragment of audio waveform
+   */
 typedef struct AudioFragment {
     // index of the first sample of this fragment in the overall waveform;
     // 0: input sample position
@@ -60,15 +60,15 @@ typedef struct AudioFragment {
     int64_t position[2];
 
     // original packed multi-channel samples:
-    uint8_t *data;
+    uint8_t* data;
 
     // number of samples in this fragment:
     int nsamples;
 
     // rDFT transform of the down-mixed mono fragment, used for
     // fast waveform alignment via correlation in frequency domain:
-    float *xdat_in;
-    float *xdat;
+    float* xdat_in;
+    float* xdat;
 } AudioFragment;
 
 /**
@@ -86,11 +86,11 @@ typedef enum {
  * Filter state machine
  */
 typedef struct ATempoContext {
-    const AVClass *class;
+    const AVClass* class;
 
     // ring-buffer of input samples, necessary because some times
     // input fragment position may be adjusted backwards:
-    uint8_t *buffer;
+    uint8_t* buffer;
 
     // ring-buffer maximum capacity, expressed in sample rate time base:
     int ring;
@@ -122,7 +122,7 @@ typedef struct ATempoContext {
 
     // Hann window coefficients, for feathering
     // (blending) the overlapping fragment region:
-    float *hann;
+    float* hann;
 
     // tempo scaling factor:
     double tempo;
@@ -141,16 +141,16 @@ typedef struct ATempoContext {
     FilterState state;
 
     // for fast correlation calculation in frequency domain:
-    AVTXContext *real_to_complex;
-    AVTXContext *complex_to_real;
+    AVTXContext* real_to_complex;
+    AVTXContext* complex_to_real;
     av_tx_fn r2c_fn, c2r_fn;
-    float *correlation_in;
-    float *correlation;
+    float* correlation_in;
+    float* correlation;
 
     // for managing AVFilterPad.request_frame and AVFilterPad.filter_frame
-    AVFrame *dst_buffer;
-    uint8_t *dst;
-    uint8_t *dst_end;
+    AVFrame* dst_buffer;
+    uint8_t* dst;
+    uint8_t* dst_end;
     uint64_t nsamples_in;
     uint64_t nsamples_out;
 } ATempoContext;
@@ -162,7 +162,7 @@ typedef struct ATempoContext {
 
 static const AVOption atempo_options[] = {
     { "tempo", "set tempo scale factor",
-      OFFSET(tempo), AV_OPT_TYPE_DOUBLE, { .dbl = 1.0 },
+      OFFSET(tempo), AV_OPT_TYPE_DOUBLE, {.dbl = 1.0 },
       YAE_ATEMPO_MIN,
       YAE_ATEMPO_MAX,
       AV_OPT_FLAG_AUDIO_PARAM | AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_RUNTIME_PARAM },
@@ -171,21 +171,18 @@ static const AVOption atempo_options[] = {
 
 AVFILTER_DEFINE_CLASS(atempo);
 
-inline static AudioFragment *yae_curr_frag(ATempoContext *atempo)
-{
+inline static AudioFragment* yae_curr_frag(ATempoContext* atempo) {
     return &atempo->frag[atempo->nfrag % 2];
 }
 
-inline static AudioFragment *yae_prev_frag(ATempoContext *atempo)
-{
+inline static AudioFragment* yae_prev_frag(ATempoContext* atempo) {
     return &atempo->frag[(atempo->nfrag + 1) % 2];
 }
 
 /**
  * Reset filter to initial state, do not deallocate existing local buffers.
  */
-static void yae_clear(ATempoContext *atempo)
-{
+static void yae_clear(ATempoContext* atempo) {
     atempo->size = 0;
     atempo->head = 0;
     atempo->tail = 0;
@@ -202,11 +199,11 @@ static void yae_clear(ATempoContext *atempo)
 
     atempo->frag[0].position[0] = 0;
     atempo->frag[0].position[1] = 0;
-    atempo->frag[0].nsamples    = 0;
+    atempo->frag[0].nsamples = 0;
 
     atempo->frag[1].position[0] = 0;
     atempo->frag[1].position[1] = 0;
-    atempo->frag[1].nsamples    = 0;
+    atempo->frag[1].nsamples = 0;
 
     // shift left position of 1st fragment by half a window
     // so that no re-normalization would be required for
@@ -215,18 +212,17 @@ static void yae_clear(ATempoContext *atempo)
     atempo->frag[0].position[1] = -(int64_t)(atempo->window / 2);
 
     av_frame_free(&atempo->dst_buffer);
-    atempo->dst     = NULL;
+    atempo->dst = NULL;
     atempo->dst_end = NULL;
 
-    atempo->nsamples_in       = 0;
-    atempo->nsamples_out      = 0;
+    atempo->nsamples_in = 0;
+    atempo->nsamples_out = 0;
 }
 
 /**
  * Reset filter to initial state and deallocate all buffers.
  */
-static void yae_release_buffers(ATempoContext *atempo)
-{
+static void yae_release_buffers(ATempoContext* atempo) {
     yae_clear(atempo);
 
     av_freep(&atempo->frag[0].data);
@@ -257,24 +253,23 @@ static void yae_release_buffers(ATempoContext *atempo)
         }                                                       \
     } while (0)
 
-/**
- * Prepare filter for processing audio data of given format,
- * sample rate and number of channels.
- */
-static int yae_reset(ATempoContext *atempo,
-                     enum AVSampleFormat format,
-                     int sample_rate,
-                     int channels)
-{
+ /**
+  * Prepare filter for processing audio data of given format,
+  * sample rate and number of channels.
+  */
+static int yae_reset(ATempoContext* atempo,
+    enum AVSampleFormat format,
+    int sample_rate,
+    int channels) {
     const int sample_size = av_get_bytes_per_sample(format);
-    uint32_t nlevels  = 0;
+    uint32_t nlevels = 0;
     float scale = 1.f, iscale = 1.f;
     uint32_t pot;
     int i;
 
-    atempo->format   = format;
+    atempo->format = format;
     atempo->channels = channels;
-    atempo->stride   = sample_size * channels;
+    atempo->stride = sample_size * channels;
 
     // pick a segment window size:
     atempo->window = sample_rate / 24;
@@ -332,10 +327,9 @@ static int yae_reset(ATempoContext *atempo,
     return 0;
 }
 
-static int yae_update(AVFilterContext *ctx)
-{
-    const AudioFragment *prev;
-    ATempoContext *atempo = ctx->priv;
+static int yae_update(AVFilterContext* ctx) {
+    const AudioFragment* prev;
+    ATempoContext* atempo = ctx->priv;
 
     prev = yae_prev_frag(atempo);
     atempo->origin[0] = prev->position[0] + atempo->window / 2;
@@ -393,27 +387,30 @@ static int yae_update(AVFilterContext *ctx)
         }                                                               \
     } while (0)
 
-/**
- * Initialize complex data buffer of a given audio fragment
- * with down-mixed mono data of appropriate scalar type.
- */
-static void yae_downmix(ATempoContext *atempo, AudioFragment *frag)
-{
+ /**
+  * Initialize complex data buffer of a given audio fragment
+  * with down-mixed mono data of appropriate scalar type.
+  */
+static void yae_downmix(ATempoContext* atempo, AudioFragment* frag) {
     // shortcuts:
-    const uint8_t *src = frag->data;
+    const uint8_t* src = frag->data;
 
     // init complex data buffer used for FFT and Correlation:
     memset(frag->xdat_in, 0, sizeof(AVComplexFloat) * (atempo->window + 1));
 
     if (atempo->format == AV_SAMPLE_FMT_U8) {
         yae_init_xdat(uint8_t, 127);
-    } else if (atempo->format == AV_SAMPLE_FMT_S16) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_S16) {
         yae_init_xdat(int16_t, 32767);
-    } else if (atempo->format == AV_SAMPLE_FMT_S32) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_S32) {
         yae_init_xdat(int, 2147483647);
-    } else if (atempo->format == AV_SAMPLE_FMT_FLT) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_FLT) {
         yae_init_xdat(float, 1);
-    } else if (atempo->format == AV_SAMPLE_FMT_DBL) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_DBL) {
         yae_init_xdat(double, 1);
     }
 }
@@ -425,13 +422,12 @@ static void yae_downmix(ATempoContext *atempo, AudioFragment *frag)
  *   0 if requested data was already available or was successfully loaded,
  *   AVERROR(EAGAIN) if more input data is required.
  */
-static int yae_load_data(ATempoContext *atempo,
-                         const uint8_t **src_ref,
-                         const uint8_t *src_end,
-                         int64_t stop_here)
-{
+static int yae_load_data(ATempoContext* atempo,
+    const uint8_t** src_ref,
+    const uint8_t* src_end,
+    int64_t stop_here) {
     // shortcut:
-    const uint8_t *src = *src_ref;
+    const uint8_t* src = *src_ref;
     const int read_size = stop_here - atempo->position[0];
 
     if (stop_here <= atempo->position[0]) {
@@ -454,7 +450,7 @@ static int yae_load_data(ATempoContext *atempo,
         nb = FFMIN(nsamples - na, atempo->ring);
 
         if (na) {
-            uint8_t *a = atempo->buffer + atempo->tail * atempo->stride;
+            uint8_t* a = atempo->buffer + atempo->tail * atempo->stride;
             memcpy(a, src, na * atempo->stride);
 
             src += na * atempo->stride;
@@ -469,7 +465,7 @@ static int yae_load_data(ATempoContext *atempo,
         }
 
         if (nb) {
-            uint8_t *b = atempo->buffer;
+            uint8_t* b = atempo->buffer;
             memcpy(b, src, nb * atempo->stride);
 
             src += nb * atempo->stride;
@@ -500,16 +496,15 @@ static int yae_load_data(ATempoContext *atempo,
  *   0 when the fragment is ready,
  *   AVERROR(EAGAIN) if more input data is required.
  */
-static int yae_load_frag(ATempoContext *atempo,
-                         const uint8_t **src_ref,
-                         const uint8_t *src_end)
-{
+static int yae_load_frag(ATempoContext* atempo,
+    const uint8_t** src_ref,
+    const uint8_t* src_end) {
     // shortcuts:
-    AudioFragment *frag = yae_curr_frag(atempo);
-    uint8_t *dst;
+    AudioFragment* frag = yae_curr_frag(atempo);
+    uint8_t* dst;
     int64_t missing, start, zeros;
     uint32_t nsamples;
-    const uint8_t *a, *b;
+    const uint8_t* a, * b;
     int i0, i1, n0, n1, na, nb;
 
     int64_t stop_here = frag->position[0] + atempo->window;
@@ -531,25 +526,25 @@ static int yae_load_frag(ATempoContext *atempo,
     dst = frag->data;
 
     start = atempo->position[0] - atempo->size;
-    zeros = 0;
+    // what we don't have we substitute with zeros:
+    zeros = frag->position[0] < start ? FFMIN(start - frag->position[0], (int64_t)nsamples) : 0;
+
+    if (zeros == nsamples) {
+        return 0;
+    }
 
     if (frag->position[0] < start) {
-        // what we don't have we substitute with zeros:
-        zeros = FFMIN(start - frag->position[0], (int64_t)nsamples);
         av_assert0(zeros != nsamples);
 
         memset(dst, 0, zeros * atempo->stride);
         dst += zeros * atempo->stride;
     }
 
-    if (zeros == nsamples) {
-        return 0;
-    }
 
     // get the remaining data from the ring buffer:
     na = (atempo->head < atempo->tail ?
-          atempo->tail - atempo->head :
-          atempo->ring - atempo->head);
+        atempo->tail - atempo->head :
+        atempo->ring - atempo->head);
 
     nb = atempo->head < atempo->tail ? 0 : atempo->tail;
 
@@ -580,12 +575,11 @@ static int yae_load_frag(ATempoContext *atempo,
 /**
  * Prepare for loading next audio fragment.
  */
-static void yae_advance_to_next_frag(ATempoContext *atempo)
-{
+static void yae_advance_to_next_frag(ATempoContext* atempo) {
     const double fragment_step = atempo->tempo * (double)(atempo->window / 2);
 
-    const AudioFragment *prev;
-    AudioFragment       *frag;
+    const AudioFragment* prev;
+    AudioFragment* frag;
 
     atempo->nfrag++;
     prev = yae_prev_frag(atempo);
@@ -593,7 +587,7 @@ static void yae_advance_to_next_frag(ATempoContext *atempo)
 
     frag->position[0] = prev->position[0] + (int64_t)fragment_step;
     frag->position[1] = prev->position[1] + atempo->window / 2;
-    frag->nsamples    = 0;
+    frag->nsamples = 0;
 }
 
 /**
@@ -602,15 +596,14 @@ static void yae_advance_to_next_frag(ATempoContext *atempo)
  * Multiply two vectors of complex numbers (result of real_to_complex rDFT)
  * and transform back via complex_to_real rDFT.
  */
-static void yae_xcorr_via_rdft(float *xcorr_in,
-                               float *xcorr,
-                               AVTXContext *complex_to_real,
-                               av_tx_fn c2r_fn,
-                               const AVComplexFloat *xa,
-                               const AVComplexFloat *xb,
-                               const int window)
-{
-    AVComplexFloat *xc = (AVComplexFloat *)xcorr_in;
+static void yae_xcorr_via_rdft(float* xcorr_in,
+    float* xcorr,
+    AVTXContext* complex_to_real,
+    av_tx_fn c2r_fn,
+    const AVComplexFloat* xa,
+    const AVComplexFloat* xb,
+    const int window) {
+    AVComplexFloat* xc = (AVComplexFloat*)xcorr_in;
     int i;
 
     for (i = 0; i <= window; i++, xa++, xb++, xc++) {
@@ -628,31 +621,30 @@ static void yae_xcorr_via_rdft(float *xcorr_in,
  *
  * @return alignment offset of current fragment relative to previous.
  */
-static int yae_align(AudioFragment *frag,
-                     const AudioFragment *prev,
-                     const int window,
-                     const int delta_max,
-                     const int drift,
-                     float *correlation_in,
-                     float *correlation,
-                     AVTXContext *complex_to_real,
-                     av_tx_fn c2r_fn)
-{
+static int yae_align(AudioFragment* frag,
+    const AudioFragment* prev,
+    const int window,
+    const int delta_max,
+    const int drift,
+    float* correlation_in,
+    float* correlation,
+    AVTXContext* complex_to_real,
+    av_tx_fn c2r_fn) {
     int       best_offset = -drift;
     float     best_metric = -FLT_MAX;
-    float    *xcorr;
+    float* xcorr;
 
     int i0;
     int i1;
     int i;
 
     yae_xcorr_via_rdft(correlation_in,
-                       correlation,
-                       complex_to_real,
-                       c2r_fn,
-                       (const AVComplexFloat *)prev->xdat,
-                       (const AVComplexFloat *)frag->xdat,
-                       window);
+        correlation,
+        complex_to_real,
+        c2r_fn,
+        (const AVComplexFloat*)prev->xdat,
+        (const AVComplexFloat*)frag->xdat,
+        window);
 
     // identify search window boundaries:
     i0 = FFMAX(window / 2 - delta_max - drift, 0);
@@ -686,10 +678,9 @@ static int yae_align(AudioFragment *frag,
  *
  * @return alignment correction.
  */
-static int yae_adjust_position(ATempoContext *atempo)
-{
-    const AudioFragment *prev = yae_prev_frag(atempo);
-    AudioFragment       *frag = yae_curr_frag(atempo);
+static int yae_adjust_position(ATempoContext* atempo) {
+    const AudioFragment* prev = yae_prev_frag(atempo);
+    AudioFragment* frag = yae_curr_frag(atempo);
 
     const double prev_output_position =
         (double)(prev->position[1] - atempo->origin[1] + atempo->window / 2) *
@@ -700,16 +691,16 @@ static int yae_adjust_position(ATempoContext *atempo)
 
     const int drift = (int)(prev_output_position - ideal_output_position);
 
-    const int delta_max  = atempo->window / 2;
+    const int delta_max = atempo->window / 2;
     const int correction = yae_align(frag,
-                                     prev,
-                                     atempo->window,
-                                     delta_max,
-                                     drift,
-                                     atempo->correlation_in,
-                                     atempo->correlation,
-                                     atempo->complex_to_real,
-                                     atempo->c2r_fn);
+        prev,
+        atempo->window,
+        delta_max,
+        drift,
+        atempo->correlation_in,
+        atempo->correlation,
+        atempo->complex_to_real,
+        atempo->c2r_fn);
 
     if (correction) {
         // adjust fragment position:
@@ -755,54 +746,57 @@ static int yae_adjust_position(ATempoContext *atempo)
         dst = (uint8_t *)out;                                           \
     } while (0)
 
-/**
- * Blend the overlap region of previous and current audio fragment
- * and output the results to the given destination buffer.
- *
- * @return
- *   0 if the overlap region was completely stored in the dst buffer,
- *   AVERROR(EAGAIN) if more destination buffer space is required.
- */
-static int yae_overlap_add(ATempoContext *atempo,
-                           uint8_t **dst_ref,
-                           uint8_t *dst_end)
-{
+ /**
+  * Blend the overlap region of previous and current audio fragment
+  * and output the results to the given destination buffer.
+  *
+  * @return
+  *   0 if the overlap region was completely stored in the dst buffer,
+  *   AVERROR(EAGAIN) if more destination buffer space is required.
+  */
+static int yae_overlap_add(ATempoContext* atempo,
+    uint8_t** dst_ref,
+    uint8_t* dst_end) {
     // shortcuts:
-    const AudioFragment *prev = yae_prev_frag(atempo);
-    const AudioFragment *frag = yae_curr_frag(atempo);
+    const AudioFragment* prev = yae_prev_frag(atempo);
+    const AudioFragment* frag = yae_curr_frag(atempo);
 
     const int64_t start_here = FFMAX(atempo->position[1],
-                                     frag->position[1]);
+        frag->position[1]);
 
     const int64_t stop_here = FFMIN(prev->position[1] + prev->nsamples,
-                                    frag->position[1] + frag->nsamples);
+        frag->position[1] + frag->nsamples);
 
     const int64_t overlap = stop_here - start_here;
 
     const int64_t ia = start_here - prev->position[1];
     const int64_t ib = start_here - frag->position[1];
 
-    const float *wa = atempo->hann + ia;
-    const float *wb = atempo->hann + ib;
+    const float* wa = atempo->hann + ia;
+    const float* wb = atempo->hann + ib;
 
-    const uint8_t *a = prev->data + ia * atempo->stride;
-    const uint8_t *b = frag->data + ib * atempo->stride;
+    const uint8_t* a = prev->data + ia * atempo->stride;
+    const uint8_t* b = frag->data + ib * atempo->stride;
 
-    uint8_t *dst = *dst_ref;
+    uint8_t* dst = *dst_ref;
 
     av_assert0(start_here <= stop_here &&
-               frag->position[1] <= start_here &&
-               overlap <= frag->nsamples);
+        frag->position[1] <= start_here &&
+        overlap <= frag->nsamples);
 
     if (atempo->format == AV_SAMPLE_FMT_U8) {
         yae_blend(uint8_t);
-    } else if (atempo->format == AV_SAMPLE_FMT_S16) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_S16) {
         yae_blend(int16_t);
-    } else if (atempo->format == AV_SAMPLE_FMT_S32) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_S32) {
         yae_blend(int);
-    } else if (atempo->format == AV_SAMPLE_FMT_FLT) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_FLT) {
         yae_blend(float);
-    } else if (atempo->format == AV_SAMPLE_FMT_DBL) {
+    }
+    else if (atempo->format == AV_SAMPLE_FMT_DBL) {
         yae_blend(double);
     }
 
@@ -818,12 +812,11 @@ static int yae_overlap_add(ATempoContext *atempo,
  * as it is able to produce or store.
  */
 static void
-yae_apply(ATempoContext *atempo,
-          const uint8_t **src_ref,
-          const uint8_t *src_end,
-          uint8_t **dst_ref,
-          uint8_t *dst_end)
-{
+yae_apply(ATempoContext* atempo,
+    const uint8_t** src_ref,
+    const uint8_t* src_end,
+    uint8_t** dst_ref,
+    uint8_t* dst_end) {
     while (1) {
         if (atempo->state == YAE_LOAD_FRAGMENT) {
             // load additional data for the current fragment:
@@ -852,7 +845,8 @@ yae_apply(ATempoContext *atempo,
                 // reload the fragment at the corrected position, so that the
                 // Hann window blending would not require normalization:
                 atempo->state = YAE_RELOAD_FRAGMENT;
-            } else {
+            }
+            else {
                 atempo->state = YAE_OUTPUT_OVERLAP_ADD;
             }
         }
@@ -892,18 +886,17 @@ yae_apply(ATempoContext *atempo,
  *   0 if all data was completely stored in the dst buffer,
  *   AVERROR(EAGAIN) if more destination buffer space is required.
  */
-static int yae_flush(ATempoContext *atempo,
-                     uint8_t **dst_ref,
-                     uint8_t *dst_end)
-{
-    AudioFragment *frag = yae_curr_frag(atempo);
+static int yae_flush(ATempoContext* atempo,
+    uint8_t** dst_ref,
+    uint8_t* dst_end) {
+    AudioFragment* frag = yae_curr_frag(atempo);
     int64_t overlap_end;
     int64_t start_here;
     int64_t stop_here;
     int64_t offset;
 
-    const uint8_t *src;
-    uint8_t *dst;
+    const uint8_t* src;
+    uint8_t* dst;
 
     int src_size;
     int dst_size;
@@ -943,7 +936,7 @@ static int yae_flush(ATempoContext *atempo,
 
     // flush the overlap region:
     overlap_end = frag->position[1] + FFMIN(atempo->window / 2,
-                                            frag->nsamples);
+        frag->nsamples);
 
     while (atempo->position[1] < overlap_end) {
         if (yae_overlap_add(atempo, dst_ref, dst_end) != 0) {
@@ -959,12 +952,12 @@ static int yae_flush(ATempoContext *atempo,
 
     // flush the remainder of the current fragment:
     start_here = FFMAX(atempo->position[1], overlap_end);
-    stop_here  = frag->position[1] + frag->nsamples;
-    offset     = start_here - frag->position[1];
+    stop_here = frag->position[1] + frag->nsamples;
+    offset = start_here - frag->position[1];
     av_assert0(start_here <= stop_here && frag->position[1] <= start_here);
 
     src = frag->data + offset * atempo->stride;
-    dst = (uint8_t *)*dst_ref;
+    dst = (uint8_t*)*dst_ref;
 
     src_size = (int)(stop_here - start_here) * atempo->stride;
     dst_size = dst_end - dst;
@@ -976,44 +969,41 @@ static int yae_flush(ATempoContext *atempo,
     atempo->position[1] += (nbytes / atempo->stride);
 
     // pass-back the updated destination buffer pointer:
-    *dst_ref = (uint8_t *)dst;
+    *dst_ref = (uint8_t*)dst;
 
     return atempo->position[1] == stop_here ? 0 : AVERROR(EAGAIN);
 }
 
-static av_cold int init(AVFilterContext *ctx)
-{
-    ATempoContext *atempo = ctx->priv;
+static av_cold int init(AVFilterContext* ctx) {
+    ATempoContext* atempo = ctx->priv;
     atempo->format = AV_SAMPLE_FMT_NONE;
-    atempo->state  = YAE_LOAD_FRAGMENT;
+    atempo->state = YAE_LOAD_FRAGMENT;
     return 0;
 }
 
-static av_cold void uninit(AVFilterContext *ctx)
-{
-    ATempoContext *atempo = ctx->priv;
+static av_cold void uninit(AVFilterContext* ctx) {
+    ATempoContext* atempo = ctx->priv;
     yae_release_buffers(atempo);
 }
 
-    // WSOLA necessitates an internal sliding window ring buffer
-    // for incoming audio stream.
-    //
-    // Planar sample formats are too cumbersome to store in a ring buffer,
-    // therefore planar sample formats are not supported.
-    //
-    static const enum AVSampleFormat sample_fmts[] = {
-        AV_SAMPLE_FMT_U8,
-        AV_SAMPLE_FMT_S16,
-        AV_SAMPLE_FMT_S32,
-        AV_SAMPLE_FMT_FLT,
-        AV_SAMPLE_FMT_DBL,
-        AV_SAMPLE_FMT_NONE
-    };
+// WSOLA necessitates an internal sliding window ring buffer
+// for incoming audio stream.
+//
+// Planar sample formats are too cumbersome to store in a ring buffer,
+// therefore planar sample formats are not supported.
+//
+static const enum AVSampleFormat sample_fmts[] = {
+    AV_SAMPLE_FMT_U8,
+    AV_SAMPLE_FMT_S16,
+    AV_SAMPLE_FMT_S32,
+    AV_SAMPLE_FMT_FLT,
+    AV_SAMPLE_FMT_DBL,
+    AV_SAMPLE_FMT_NONE
+};
 
-static int config_props(AVFilterLink *inlink)
-{
-    AVFilterContext  *ctx = inlink->dst;
-    ATempoContext *atempo = ctx->priv;
+static int config_props(AVFilterLink* inlink) {
+    AVFilterContext* ctx = inlink->dst;
+    ATempoContext* atempo = ctx->priv;
 
     enum AVSampleFormat format = inlink->format;
     int sample_rate = (int)inlink->sample_rate;
@@ -1021,25 +1011,26 @@ static int config_props(AVFilterLink *inlink)
     return yae_reset(atempo, format, sample_rate, inlink->ch_layout.nb_channels);
 }
 
-static int push_samples(ATempoContext *atempo,
-                        AVFilterLink *outlink,
-                        int n_out)
-{
+static int push_samples(ATempoContext* atempo,
+    AVFilterLink* outlink,
+    int n_out) {
     int ret;
 
     atempo->dst_buffer->sample_rate = outlink->sample_rate;
-    atempo->dst_buffer->nb_samples  = n_out;
+    atempo->dst_buffer->nb_samples = n_out;
 
     // adjust the PTS:
     atempo->dst_buffer->pts = atempo->start_pts +
         av_rescale_q(atempo->nsamples_out,
-                     (AVRational){ 1, outlink->sample_rate },
-                     outlink->time_base);
+            (AVRational) {
+        1, outlink->sample_rate
+    },
+            outlink->time_base);
 
     ret = ff_filter_frame(outlink, atempo->dst_buffer);
     atempo->dst_buffer = NULL;
-    atempo->dst        = NULL;
-    atempo->dst_end    = NULL;
+    atempo->dst = NULL;
+    atempo->dst_end = NULL;
     if (ret < 0)
         return ret;
 
@@ -1047,23 +1038,22 @@ static int push_samples(ATempoContext *atempo,
     return 0;
 }
 
-static int filter_frame(AVFilterLink *inlink, AVFrame *src_buffer)
-{
-    AVFilterContext  *ctx = inlink->dst;
-    ATempoContext *atempo = ctx->priv;
-    AVFilterLink *outlink = ctx->outputs[0];
+static int filter_frame(AVFilterLink* inlink, AVFrame* src_buffer) {
+    AVFilterContext* ctx = inlink->dst;
+    ATempoContext* atempo = ctx->priv;
+    AVFilterLink* outlink = ctx->outputs[0];
 
     int ret = 0;
     int n_in = src_buffer->nb_samples;
     int n_out = (int)(0.5 + ((double)n_in) / atempo->tempo);
 
-    const uint8_t *src = src_buffer->data[0];
-    const uint8_t *src_end = src + n_in * atempo->stride;
+    const uint8_t* src = src_buffer->data[0];
+    const uint8_t* src_end = src + n_in * atempo->stride;
 
     if (atempo->start_pts == AV_NOPTS_VALUE)
         atempo->start_pts = av_rescale_q(src_buffer->pts,
-                                         inlink->time_base,
-                                         outlink->time_base);
+            inlink->time_base,
+            outlink->time_base);
 
     while (src < src_end) {
         if (!atempo->dst_buffer) {
@@ -1082,7 +1072,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *src_buffer)
 
         if (atempo->dst == atempo->dst_end) {
             int n_samples = ((atempo->dst - atempo->dst_buffer->data[0]) /
-                             atempo->stride);
+                atempo->stride);
             ret = push_samples(atempo, outlink, n_samples);
             if (ret < 0)
                 goto end;
@@ -1095,10 +1085,9 @@ end:
     return ret;
 }
 
-static int request_frame(AVFilterLink *outlink)
-{
-    AVFilterContext  *ctx = outlink->src;
-    ATempoContext *atempo = ctx->priv;
+static int request_frame(AVFilterLink* outlink) {
+    AVFilterContext* ctx = outlink->src;
+    ATempoContext* atempo = ctx->priv;
     int ret;
 
     ret = ff_request_frame(ctx->inputs[0]);
@@ -1122,7 +1111,7 @@ static int request_frame(AVFilterLink *outlink)
             err = yae_flush(atempo, &atempo->dst, atempo->dst_end);
 
             n_out = ((atempo->dst - atempo->dst_buffer->data[0]) /
-                     atempo->stride);
+                atempo->stride);
 
             if (n_out) {
                 ret = push_samples(atempo, outlink, n_out);
@@ -1132,7 +1121,7 @@ static int request_frame(AVFilterLink *outlink)
         }
 
         av_frame_free(&atempo->dst_buffer);
-        atempo->dst     = NULL;
+        atempo->dst = NULL;
         atempo->dst_end = NULL;
 
         return AVERROR_EOF;
@@ -1141,13 +1130,12 @@ static int request_frame(AVFilterLink *outlink)
     return ret;
 }
 
-static int process_command(AVFilterContext *ctx,
-                           const char *cmd,
-                           const char *arg,
-                           char *res,
-                           int res_len,
-                           int flags)
-{
+static int process_command(AVFilterContext* ctx,
+    const char* cmd,
+    const char* arg,
+    char* res,
+    int res_len,
+    int flags) {
     int ret = ff_filter_process_command(ctx, cmd, arg, res, res_len, flags);
 
     if (ret < 0)
@@ -1158,8 +1146,8 @@ static int process_command(AVFilterContext *ctx,
 
 static const AVFilterPad atempo_inputs[] = {
     {
-        .name         = "default",
-        .type         = AVMEDIA_TYPE_AUDIO,
+        .name = "default",
+        .type = AVMEDIA_TYPE_AUDIO,
         .filter_frame = filter_frame,
         .config_props = config_props,
     },
@@ -1167,20 +1155,20 @@ static const AVFilterPad atempo_inputs[] = {
 
 static const AVFilterPad atempo_outputs[] = {
     {
-        .name          = "default",
+        .name = "default",
         .request_frame = request_frame,
-        .type          = AVMEDIA_TYPE_AUDIO,
+        .type = AVMEDIA_TYPE_AUDIO,
     },
 };
 
 const AVFilter ff_af_atempo = {
-    .name            = "atempo",
-    .description     = NULL_IF_CONFIG_SMALL("Adjust audio tempo."),
-    .init            = init,
-    .uninit          = uninit,
+    .name = "atempo",
+    .description = NULL_IF_CONFIG_SMALL("Adjust audio tempo."),
+    .init = init,
+    .uninit = uninit,
     .process_command = process_command,
-    .priv_size       = sizeof(ATempoContext),
-    .priv_class      = &atempo_class,
+    .priv_size = sizeof(ATempoContext),
+    .priv_class = &atempo_class,
     FILTER_INPUTS(atempo_inputs),
     FILTER_OUTPUTS(atempo_outputs),
     FILTER_SAMPLEFMTS_ARRAY(sample_fmts),


### PR DESCRIPTION
Check for zeros equal to the total samples early, because in case the check is true we would already be leaving the first few frames out. #10692