### PR TITLE
af_tempo.c: fix checking of samples and zero frame counts

### DIFF
--- a/libavfilter/af_atempo.c
+++ b/libavfilter/af_atempo.c
@@ -531,19 +531,19 @@ static int yae_load_frag(ATempoContext *atempo,
     dst = frag->data;
 
     start = atempo->position[0] - atempo->size;
-    zeros = 0;
+    // what we don't have we substitute with zeros:
+    zeros = frag->position[0] < start ? FFMIN(start - frag->position[0], (int64_t)nsamples) : 0;
+
+    if (zeros == nsamples) {
+        return 0;
+    }
 
     if (frag->position[0] < start) {
-        // what we don't have we substitute with zeros:
-        zeros = FFMIN(start - frag->position[0], (int64_t)nsamples);
+
         av_assert0(zeros != nsamples);
 
         memset(dst, 0, zeros * atempo->stride);
         dst += zeros * atempo->stride;
-    }
-
-    if (zeros == nsamples) {
-        return 0;
     }
 
     // get the remaining data from the ring buffer:


### PR DESCRIPTION
Check for zeros equal to the total samples early, because in case the check is true we would already be leaving the first few frames out. #10692